### PR TITLE
Handle every fallback request

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -69,11 +69,11 @@ class UnknownSkill(NeonFallbackSkill):
         # This checks if we're pretty sure this was a request intended for Neon
         if not (self.neon_in_request(message) or
                 self.neon_must_respond(message)):
-            return False
+            return True
 
         # Ignore likely accidental activations
         if len(utterance.split()) < 2:
-            return False
+            return True
 
         try:
             # Report an intent failure
@@ -109,14 +109,8 @@ class UnknownSkill(NeonFallbackSkill):
                         self.speak("I'm not sure how to help you with that.")
                     return True
 
-        # Not a question, if it's for Neon, reply "I don't know"
-        if self.neon_in_request(message):
-            # TODO: Refactor default response handling DM
-            if not get_user_prefs(
-                    message)['response_mode'].get("limit_dialog"):
-                self.speak_dialog('unknown')
-            else:
-                self.speak("I'm not sure how to help you with that.")
+        # Not a question, but it's for Neon, reply "I don't know"
+        self.speak_dialog('unknown')
         return True
 
 

--- a/__init__.py
+++ b/__init__.py
@@ -102,14 +102,8 @@ class UnknownSkill(NeonFallbackSkill):
             for line in self._read_voc_lines(i):
                 if utterance.startswith(line):
                     LOG.info('Fallback type: ' + i)
-                    if not get_user_prefs(
-                            message)['response_mode'].get("limit_dialog"):
-                        self.speak_dialog(i,
-                                          data={
-                                              'remaining': line.replace(i, '')
-                                          })
-                    else:
-                        self.speak("I'm not sure how to help you with that.")
+                    self.speak_dialog(i,
+                                      data={'remaining': line.replace(i, '')})
                     return True
 
         # Not a question, but it's for Neon, reply "I don't know"

--- a/__init__.py
+++ b/__init__.py
@@ -69,10 +69,12 @@ class UnknownSkill(NeonFallbackSkill):
         # This checks if we're pretty sure this was a request intended for Neon
         if not (self.neon_in_request(message) or
                 self.neon_must_respond(message)):
+            LOG.info("Ignoring streaming STT or public conversation input")
             return True
 
         # Ignore likely accidental activations
         if len(utterance.split()) < 2:
+            LOG.info(f"Ignoring 1-word input: {utterance}")
             return True
 
         try:

--- a/__init__.py
+++ b/__init__.py
@@ -85,6 +85,7 @@ class UnknownSkill(NeonFallbackSkill):
         except Exception as e:
             LOG.exception(e)
         LOG.debug(f"Checking if neon must respond: {message.data}")
+        # TODO: This should be handled in a separate fallback skill
         if self.neon_must_respond(message):
             if request_from_mobile(message):
                 pass

--- a/test/test_skill.py
+++ b/test/test_skill.py
@@ -122,9 +122,13 @@ class TestSkill(unittest.TestCase):
         message_unknown = Message("test", {"neon_in_request": True,
                                            "utterance": "is it raining"})
 
-        self.assertFalse(self.skill.handle_fallback(message_not_for_neon))
-        self.assertFalse(self.skill.handle_fallback(message_too_short))
+        self.assertTrue(self.skill.handle_fallback(message_not_for_neon))
+        self.skill.speak_dialog.assert_not_called()
+        self.assertTrue(self.skill.handle_fallback(message_too_short))
+        self.skill.speak_dialog.assert_not_called()
+
         self.assertTrue(self.skill.handle_fallback(message_neon_must_respond))
+        self.skill.speak_dialog.assert_not_called()
 
         self.assertTrue(self.skill.handle_fallback(message_question))
         self.skill.speak_dialog.assert_called_once()


### PR DESCRIPTION
Always handle utterances so we don't get "still starting up" spoken dialog
Add logging when utterances are ignored to troubleshoot bad transcriptions